### PR TITLE
xdp: Add XdpContext method to access data as &[u8]

### DIFF
--- a/bpf/aya-bpf/src/programs/xdp.rs
+++ b/bpf/aya-bpf/src/programs/xdp.rs
@@ -7,16 +7,42 @@ pub struct XdpContext {
 }
 
 impl XdpContext {
+
+    #[inline(always)]
     pub fn new(ctx: *mut xdp_md) -> XdpContext {
         XdpContext { ctx }
     }
 
+    #[inline(always)]
     pub fn data(&self) -> usize {
         unsafe { (*self.ctx).data as usize }
     }
 
+    #[inline(always)]
     pub fn data_end(&self) -> usize {
         unsafe { (*self.ctx).data_end as usize }
+    }
+
+    #[inline(always)]
+    pub fn data_buffer(&self) -> Option<&[u8]> {
+        unsafe {
+            let data_buffer: *const u8 = (*self.ctx).data as usize as *const u8;
+            if (*self.ctx).data_end <= (*self.ctx).data {
+                return None;
+            }
+            let data_buffer_size = ((*self.ctx).data_end - (*self.ctx).data) as usize;
+            Some(core::slice::from_raw_parts(data_buffer, data_buffer_size))
+        }
+    }
+
+    #[inline(always)]
+    pub fn data_pointer(&self) -> (*const u8, *const u8) {
+        unsafe {
+        (
+            (*self.ctx).data as usize as *const u8,
+            (*self.ctx).data_end as usize as *const u8,
+        )
+        }
     }
 }
 


### PR DESCRIPTION
This is a port of data_buffer from redbpf
https://sourcegraph.com/github.com/rebpf/rebpf@50e235721228c1ece2c685f9357a954bd4a322d3/-/blob/rebpf/src/libbpf.rs?L547:12#tab=def